### PR TITLE
Update RBIH_Token.sol

### DIFF
--- a/RBIH_Token.sol
+++ b/RBIH_Token.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.9.0/contracts/token/ERC20/ERC20.sol";
 
-contract BIHToken is ERC20 {
+contract RAYBIHToken is ERC20 {
     constructor()
-        ERC20("BIH Token", "BIH")
+        ERC20("RBIH Token", "BIH")
     {
         _mint(msg.sender, 1000000 * 10 ** decimals());
     }


### PR DESCRIPTION
There was an error with the version of the solidity compiler version. So to rectify it the OpenZeppelin framework was changed to allow support for older versions